### PR TITLE
Hideous hack to fix sick bug.

### DIFF
--- a/scaffolds/continuous-integration/circle.yml
+++ b/scaffolds/continuous-integration/circle.yml
@@ -15,6 +15,8 @@ dependencies:
   cache_directories:
     - ~/.meteor
     - ~/node_modules
+    - ~/nvm/v0.10.33/lib/node_modules/starrynight
+    - ~/nvm/v0.10.33/bin/starrynight
 
   # Dependencies of the build run before CircleCI's inferred commands
   pre:
@@ -27,16 +29,17 @@ dependencies:
     # Now install  Starrynight
     - mkdir -p ~/.meteor
     # If Meteor is already cached, do not need to build it again.
-    - if [ ! -e ~/.meteor/meteor ]; then curl https://install.meteor.com | /bin/sh; fi
-    - npm install -g starrynight
-
-
-test:
-  # Test that replace CircleCI's inferred tests
-  override:
+    - if [ ! -e ~/.meteor/meteor ]; then curl https://install.meteor.com | /bin/sh; else echo "Meteor installation seems to be cached"; fi;
     # Starrynight tests require a running copy of a Meteor app
     #    so start it up and push it into the background
     - ~/.meteor/meteor:
           background: true
+    - if [ ! -e ~/nvm/v0.10.33/bin/starrynight ]; then npm install -g starrynight; else echo "Starrynight seems to be cached"; fi;
+    # - npm install -g starrynight
+
+
+test:
+  # Tests that replace CircleCI's inferred tests
+  override:
     # Run the Nightwatch tests of your Meteor app
     - starrynight run-tests --framework nightwatch

--- a/scaffolds/continuous-integration/circle.yml
+++ b/scaffolds/continuous-integration/circle.yml
@@ -1,10 +1,42 @@
+# This is the configuration file for continuous integration of
+# your project in CircleCi.
+#
+# The full reference is available at :
+#             https://circleci.com/docs/configuration
+#
+machine:
+  node:
+    # Cannot be certain that this build wlll work with all future versions: so specify.
+    version: 0.10.33
+
 dependencies:
+  # Whatever is written to these directories during one build will be
+  #    restored verbatim on every future build.
+  cache_directories:
+    - ~/.meteor
+    - ~/node_modules
+
+  # Dependencies of the build run before CircleCI's inferred commands
   pre:
-    - curl https://install.meteor.com | /bin/sh
-    - meteor:
-          background: true
+    # Now install WebDriver
+    - mkdir -p ~/node_modules
+    # If WebDriver is already cached, do not need to build it again.
+    - if [ ! -d ~/node_modules/selenium-webdriver/ ]; then npm install --prefix ~ selenium-webdriver; else echo "Selenium Webdriver seems to be cached"; fi;
+    # Have symlink to a cached directory
+    - ln -s ~/node_modules node_modules
+    # Now install  Starrynight
+    - mkdir -p ~/.meteor
+    # If Meteor is already cached, do not need to build it again.
+    - if [ ! -e ~/.meteor/meteor ]; then curl https://install.meteor.com | /bin/sh; fi
     - npm install -g starrynight
 
+
 test:
-  post:
+  # Test that replace CircleCI's inferred tests
+  override:
+    # Starrynight tests require a running copy of a Meteor app
+    #    so start it up and push it into the background
+    - ~/.meteor/meteor:
+          background: true
+    # Run the Nightwatch tests of your Meteor app
     - starrynight run-tests --framework nightwatch

--- a/scaffolds/sample-tests/nightwatch-minimal/gitignore_example
+++ b/scaffolds/sample-tests/nightwatch-minimal/gitignore_example
@@ -1,1 +1,2 @@
 reports
+

--- a/tool/scaffold.js
+++ b/tool/scaffold.js
@@ -140,7 +140,15 @@ module.exports = function(npmPrefix, arguments, options){
         case "nightwatch-minimal":
             fs.copy(npmPrefix + '/lib/node_modules/starrynight/scaffolds/sample-tests/nightwatch-minimal', './tests/nightwatch', function (error) {
               if (error){ return console.error(error) }
-              console.log('Minimal Nightwatch validation testing framework scaffolded into project!')
+              /*
+                  Here lies one of the ugliest hacks I have been forced to make.
+                  Why in HELL would fs.copy rename every .gitnore to .npmignore??
+              */
+              fs.rename('./tests/nightwatch/gitignore_example', './tests/nightwatch/.gitignore', function (error) {
+                if (error){ return console.error(error) }
+                console.log('Renamed gitignore_example to .gitignore!')
+              });
+              console.log('A minimal Nightwatch validation testing framework scaffolded into project!')
             });
           break;
         case "nightwatch":


### PR DESCRIPTION
Cannot have files named .gitignore because fs.copy will rename to .npmignore
Now they are named gitignore_example and renamed to .gitnore after copying.
                  Why in HELL would fs.copy rename every .gitnore to .npmignore??

This is possibly some weirdness to do with Git rather than fs.copy.  I'll try to figure it out later.
 Changes committed:
    renamed:    scaffolds/sample-tests/nightwatch-minimal/.gitignore -> scaffolds/sample-tests/nightwatch-minimal/gitignore_example
    modified:   tool/scaffold.js
