### PR TITLE
Join paths together using node's path module

### DIFF
--- a/tool/frameworks/gagarin.js
+++ b/tool/frameworks/gagarin.js
@@ -3,6 +3,7 @@ var childProcess = require( "child_process" );
 var chromedriver = require( "chromedriver" );
 var _ = require( "underscore" );
 var fs = require( "fs-extra" );
+var path = require( "path" );
 
 module.exports = function(npmPrefix, options){
   var testCommand = "gagarin";
@@ -29,7 +30,7 @@ module.exports = function(npmPrefix, options){
     if (options.debug) {
       console.log('process.env.pwd + options.path', process.env.PWD + options.path);
     }
-    gagarinArguments.push( process.env.PWD + options.path );
+    gagarinArguments.push( path.join( process.env.PWD, options.path ) );
   }
 
   if (options && options.runfrom) {


### PR DESCRIPTION
This is a very simple PR that makes starrynight use Node's path module to join paths when running tests with the Gagarin framework. In our application, the development package directory is at the same level as the root of the application, so I needed to use --path ../Packages but this wasn't working with the path concatenation. Using the path module is better than concatenating the paths because it allows you to use relative paths.
